### PR TITLE
Write manual FFI entries for all MDNode class RTTI

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
@@ -14,20 +14,17 @@ import LLVM.Internal.FFI.Context
 import LLVM.Internal.FFI.PtrHierarchy
 import LLVM.Internal.FFI.LLVMCTypes
 
-foreign import ccall unsafe "LLVM_Hs_IsAMDString" isAMDString ::
-  Ptr Metadata -> IO (Ptr MDString)
+-- foreign import ccall unsafe "LLVM_Hs_IsAMDString" isAMDString ::
+--   Ptr Metadata -> IO (Ptr MDString)
 
-foreign import ccall unsafe "LLVM_Hs_IsAMDNode" isAMDNode ::
-  Ptr Metadata -> IO (Ptr MDNode)
+-- foreign import ccall unsafe "LLVM_Hs_IsAMDNode" isAMDNode ::
+--   Ptr Metadata -> IO (Ptr MDNode)
 
 foreign import ccall unsafe "LLVM_Hs_IsAMDValue" isAMDValue ::
   Ptr Metadata -> IO (Ptr MDValue)
 
 foreign import ccall unsafe "LLVM_Hs_IsAMetadataOperand" isAMetadataOperand ::
   Ptr Value -> IO (Ptr MetadataAsVal)
-
-foreign import ccall unsafe "LLVM_Hs_IsADILocation" isADILocation ::
-  Ptr MDNode -> IO (Ptr DILocation)
 
 {- Ideally this would allow for a lookup of the exact subclass rather than having to check each one
    individually. However, I don't know how to access the class "Kinds" that contain the actual Id
@@ -36,14 +33,14 @@ foreign import ccall unsafe "LLVM_Hs_IsADILocation" isADILocation ::
 foreign import ccall unsafe "LLVM_Hs_GetMetadataClassId" getMetadataClassId ::
   Ptr MDNode -> IO (CUInt)
 
-foreign import ccall unsafe "LLVM_Hs_DILocationGetLine" getLine ::
-  Ptr DILocation -> IO (CUInt)
+-- foreign import ccall unsafe "LLVM_Hs_DILocationGetLine" getLine ::
+--   Ptr DILocation -> IO (CUInt)
 
-foreign import ccall unsafe "LLVM_Hs_DILocationGetColumn" getColumn ::
-  Ptr DILocation -> IO (CUInt)
+-- foreign import ccall unsafe "LLVM_Hs_DILocationGetColumn" getColumn ::
+--   Ptr DILocation -> IO (CUInt)
 
 foreign import ccall unsafe "LLVM_HS_DILocationGetScope" getScope ::
-  Ptr DILocation -> IO (Ptr DILocalScope)
+  Ptr DIScope -> IO (Ptr DILocalScope)
 
 foreign import ccall unsafe "LLVM_Hs_GetMDValue" getMDValue ::
   Ptr MDValue -> IO (Ptr Value)
@@ -107,6 +104,128 @@ foreign import ccall unsafe "LLVM_Hs_NamedMetadataAddOperands" namedMetadataAddO
 
 foreign import ccall unsafe "LLVM_Hs_MetadataReplaceAllUsesWith" metadataReplaceAllUsesWith ::
   Ptr MDNode -> Ptr Metadata -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_IsAMDString" isAMDString ::
+  Ptr Metadata -> IO (Ptr MDString)
+
+-- foreign import ccall unsafe "LLVM_Hs_IsAValueAsMetadata" isAValueAsMetadata ::
+--   Ptr MDNode -> IO (Ptr ValueAsMetadata)
+
+-- foreign import ccall unsafe "LLVM_Hs_IsAConstantAsMetadata" isAConstantAsMetadata ::
+--   Ptr MDNode -> IO (Ptr ConstantAsMetadata)
+
+-- These are in the .def but not in the doxygen? Maybe unreleased metadata?
+-- foreign import ccall unsafe "LLVM_Hs_IsALocalAsMetadata" isALocalAsMetadata ::
+--   Ptr MDNode -> IO (Ptr LocalAsMetadata)
+
+-- foreign import ccall unsafe "LLVM_Hs_IsADistinctMDOperandPlaceholder" isADistinctMDOperandPlaceholder ::
+--   Ptr MDNode -> IO (Ptr DistinctMDOperandPlaceholder)
+
+foreign import ccall unsafe "LLVM_Hs_IsAMDNode" isAMDNode ::
+  Ptr Metadata -> IO (Ptr MDNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsAMDTuple" isAMDTuple ::
+  Ptr MDNode -> IO (Ptr MDNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADILocation" isADILocation ::
+  Ptr MDNode -> IO (Ptr MDNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIExpression" isADIExpression ::
+  Ptr MDNode -> IO (Ptr MDNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIGlobalVariableExpression" isADIGlobalVariableExpression ::
+  Ptr MDNode -> IO (Ptr MDNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADINode" isADINode ::
+  Ptr MDNode -> IO (Ptr DINode)
+
+foreign import ccall unsafe "LLVM_Hs_IsAGenericDINode" isAGenericDINode ::
+  Ptr MDNode -> IO (Ptr DINode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADISubrange" isADISubrange ::
+  Ptr MDNode -> IO (Ptr DINode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIEnumerator" isADIEnumerator ::
+  Ptr MDNode -> IO (Ptr DINode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIScope" isADIScope ::
+  Ptr MDNode -> IO (Ptr DIScope)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIType" isADIType ::
+  Ptr MDNode -> IO (Ptr DIType)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIBasicType" isADIBasicType ::
+  Ptr MDNode -> IO (Ptr DIType)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIDerivedType" isADIDerivedType ::
+  Ptr MDNode -> IO (Ptr DIType)
+
+foreign import ccall unsafe "LLVM_Hs_IsADICompositeType" isADICompositeType ::
+  Ptr MDNode -> IO (Ptr DIType)
+
+foreign import ccall unsafe "LLVM_Hs_IsADISubroutineType" isADISubroutineType ::
+  Ptr MDNode -> IO (Ptr DIType)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIFile" isADIFile ::
+  Ptr MDNode -> IO (Ptr DIFile)
+
+foreign import ccall unsafe "LLVM_Hs_IsADICompileUnit" isADICompileUnit ::
+  Ptr MDNode -> IO (Ptr DIScope)
+
+foreign import ccall unsafe "LLVM_Hs_IsADILocalScope" isADILocalScope ::
+  Ptr MDNode -> IO (Ptr DILocalScope)
+
+foreign import ccall unsafe "LLVM_Hs_IsADISubprogram" isADISubprogram ::
+  Ptr MDNode -> IO (Ptr DILocalScope)
+
+foreign import ccall unsafe "LLVM_Hs_IsADILexicalBlockBase" isADILexicalBlockBase ::
+  Ptr MDNode -> IO (Ptr DILexicalBlockBase)
+
+foreign import ccall unsafe "LLVM_Hs_IsADILexicalBlock" isADILexicalBlock ::
+  Ptr MDNode -> IO (Ptr DILexicalBlockBase)
+
+foreign import ccall unsafe "LLVM_Hs_IsADILexicalBlockFile" isADILexicalBlockFile ::
+  Ptr MDNode -> IO (Ptr DILexicalBlockBase)
+
+foreign import ccall unsafe "LLVM_Hs_IsADINamespace" isADINamespace ::
+  Ptr MDNode -> IO (Ptr DIScope)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIModule" isADIModule ::
+  Ptr MDNode -> IO (Ptr MDNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADITemplateParameter" isADITemplateParameter ::
+  Ptr MDNode -> IO (Ptr DITemplateParameter)
+
+foreign import ccall unsafe "LLVM_Hs_IsADITemplateTypeParameter" isADITemplateTypeParameter ::
+  Ptr MDNode -> IO (Ptr DITemplateParameter)
+
+foreign import ccall unsafe "LLVM_Hs_IsADITemplateValueParameter" isADITemplateValueParameter ::
+  Ptr MDNode -> IO (Ptr DITemplateParameter)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIVariable" isADIVariable ::
+  Ptr MDNode -> IO (Ptr DIVariable)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIGlobalVariable" isADIGlobalVariable ::
+  Ptr MDNode -> IO (Ptr DIVariable)
+
+foreign import ccall unsafe "LLVM_Hs_IsADILocalVariable" isADILocalVariable ::
+  Ptr MDNode -> IO (Ptr DIVariable)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIObjCProperty" isADIObjCProperty ::
+  Ptr MDNode -> IO (Ptr DINode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIImportedEntity" isADIImportedEntity ::
+  Ptr MDNode -> IO (Ptr DINode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIMacroNode" isADIMacroNode ::
+  Ptr MDNode -> IO (Ptr DIMacroNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIMacro" isADIMacro ::
+  Ptr MDNode -> IO (Ptr DIMacroNode)
+
+foreign import ccall unsafe "LLVM_Hs_IsADIMacroFile" isADIMacroFile ::
+  Ptr MDNode -> IO (Ptr DIMacroNode)
+
 
 namedMetadataAddOperands :: Ptr NamedMetadata -> (CUInt, Ptr (Ptr MDNode)) -> IO ()
 namedMetadataAddOperands nm (n, vs) = namedMetadataAddOperands' nm vs n

--- a/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
@@ -13,12 +13,54 @@ using namespace llvm;
 
 extern "C" {
 
-LLVMMetadataRef LLVM_Hs_IsAMDString(LLVMMetadataRef md) {
-    if (isa<MDString>(unwrap(md))) {
-        return md;
-    }
-    return nullptr;
+#define TEMPLATE_IS_CHECK(CLASS) \
+LLVMMetadataRef LLVM_Hs_IsA##CLASS(LLVMMetadataRef md) { \
+    if (isa<CLASS>(unwrap(md))) { \
+        return md; \
+    } \
+    return nullptr; \
 }
+
+TEMPLATE_IS_CHECK(MDString)
+TEMPLATE_IS_CHECK(ValueAsMetadata)
+TEMPLATE_IS_CHECK(ConstantAsMetadata)
+TEMPLATE_IS_CHECK(LocalAsMetadata)
+TEMPLATE_IS_CHECK(DistinctMDOperandPlaceholder)
+TEMPLATE_IS_CHECK(MDNode)
+TEMPLATE_IS_CHECK(MDTuple)
+TEMPLATE_IS_CHECK(DILocation)
+TEMPLATE_IS_CHECK(DIExpression)
+TEMPLATE_IS_CHECK(DIGlobalVariableExpression)
+TEMPLATE_IS_CHECK(DINode)
+TEMPLATE_IS_CHECK(GenericDINode)
+TEMPLATE_IS_CHECK(DISubrange)
+TEMPLATE_IS_CHECK(DIEnumerator)
+TEMPLATE_IS_CHECK(DIScope)
+TEMPLATE_IS_CHECK(DIType)
+TEMPLATE_IS_CHECK(DIBasicType)
+TEMPLATE_IS_CHECK(DIDerivedType)
+TEMPLATE_IS_CHECK(DICompositeType)
+TEMPLATE_IS_CHECK(DISubroutineType)
+TEMPLATE_IS_CHECK(DIFile)
+TEMPLATE_IS_CHECK(DICompileUnit)
+TEMPLATE_IS_CHECK(DILocalScope)
+TEMPLATE_IS_CHECK(DISubprogram)
+TEMPLATE_IS_CHECK(DILexicalBlockBase)
+TEMPLATE_IS_CHECK(DILexicalBlock)
+TEMPLATE_IS_CHECK(DILexicalBlockFile)
+TEMPLATE_IS_CHECK(DINamespace)
+TEMPLATE_IS_CHECK(DIModule)
+TEMPLATE_IS_CHECK(DITemplateParameter)
+TEMPLATE_IS_CHECK(DITemplateTypeParameter)
+TEMPLATE_IS_CHECK(DITemplateValueParameter)
+TEMPLATE_IS_CHECK(DIVariable)
+TEMPLATE_IS_CHECK(DIGlobalVariable)
+TEMPLATE_IS_CHECK(DILocalVariable)
+TEMPLATE_IS_CHECK(DIObjCProperty)
+TEMPLATE_IS_CHECK(DIImportedEntity)
+TEMPLATE_IS_CHECK(DIMacroNode)
+TEMPLATE_IS_CHECK(DIMacro)
+TEMPLATE_IS_CHECK(DIMacroFile)
 
 LLVMMetadataRef LLVM_Hs_MDStringInContext(LLVMContextRef c,
                                                const char *str, unsigned slen) {
@@ -40,13 +82,6 @@ LLVMMetadataRef LLVM_Hs_MDValue(LLVMValueRef v) {
 
 LLVMValueRef LLVM_Hs_MetadataOperand(LLVMContextRef c, LLVMMetadataRef md) {
     return wrap(MetadataAsValue::get(*unwrap(c), unwrap(md)));
-}
-
-LLVMMetadataRef LLVM_Hs_IsAMDNode(LLVMMetadataRef md) {
-    if (isa<MDNode>(unwrap(md))) {
-        return md;
-    }
-    return nullptr;
 }
 
 LLVMValueRef LLVM_Hs_GetMDValue(LLVMMetadataRef md) {
@@ -145,13 +180,6 @@ void LLVM_Hs_MetadataReplaceAllUsesWith(LLVMMetadataRef md, LLVMMetadataRef repl
     auto *Node = unwrap<MDNode>(md);
     Node->replaceAllUsesWith(unwrap<Metadata>(replacement));
     MDNode::deleteTemporary(Node);
-}
-
-LLVMMetadataRef LLVM_Hs_IsADILocation(LLVMMetadataRef md) {
-    if (isa<DILocation>(unwrap(md))) {
-        return md;
-    }
-    return nullptr;
 }
 
 unsigned LLVM_Hs_GetMetadataClassId(LLVMMetadataRef md) {

--- a/llvm-hs/src/LLVM/Internal/FFI/PtrHierarchy.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/PtrHierarchy.hs
@@ -105,14 +105,19 @@ data DIExpression
 instance ChildOf MDNode DIExpression
 
 -- | https://llvm.org/doxygen/classllvm_1_1DILocation.html
-data DILocation
+-- data DILocation
 
-instance ChildOf MDNode DILocation
+-- instance ChildOf MDNode DILocation
 
 -- | https://llvm.org/doxygen/classllvm_1_1DINode.html
 data DINode
 
 instance ChildOf MDNode DINode
+
+-- | https://llvm.org/doxygen/classllvm_1_1DIMacroNode.html
+data DIMacroNode
+
+instance ChildOf MDNode DIMacroNode
 
 -- | https://llvm.org/doxygen/classllvm_1_1DIScope.html
 data DIScope
@@ -123,6 +128,31 @@ instance ChildOf DINode DIScope
 data DILocalScope
 
 instance ChildOf DIScope DILocalScope
+
+-- | https://llvm.org/doxygen/classllvm_1_1DIVariable.html
+data DIVariable
+
+instance ChildOf DINode DIVariable
+
+-- | https://llvm.org/doxygen/classllvm_1_1DITemplateParameter.html
+data DITemplateParameter
+
+instance ChildOf DINode DITemplateParameter
+
+-- | https://llvm.org/doxygen/classllvm_1_1DIType.html
+data DIType
+
+instance ChildOf DIScope DIType
+
+-- | https://llvm.org/doxygen/classllvm_1_1DILexicalBlockBase.html
+data DILexicalBlockBase
+
+instance ChildOf DILocalScope DILexicalBlockBase
+
+-- | https://llvm.org/doxygen/classllvm_1_1DIFile.html
+data DIFile
+
+instance ChildOf DIScope DIFile
 
 -- | <http://llvm.org/doxygen/classllvm_1_1NamedMDNode.html>
 data NamedMetadata

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -55,14 +55,14 @@ instance DecodeM DecodeAST A.Metadata (Ptr FFI.Metadata) where
                               else fail "Metadata was not one of [MDString, MDValue, MDNode]"
 
 instance DecodeM DecodeAST A.MDNode (Ptr FFI.MDNode) where
-  decodeM mdn = do
-    s <- liftIO $ FFI.isADILocation mdn
-    if (s /= nullPtr)
-      then A.DILocation
-        <$> (liftIO $ fromIntegral <$> FFI.getLine s)
-        <*> (liftIO $ fromIntegral <$> FFI.getColumn s)
-        <*> (decodeM =<< (liftIO $ FFI.getScope s))
-      else fail "omg"
+  -- decodeM mdn = do
+  --   s <- liftIO $ FFI.isADILocation mdn
+    -- if (s /= nullPtr)
+    --   then A.DILocation
+    --     <$> (liftIO $ fromIntegral <$> FFI.getLine s)
+    --     <*> (liftIO $ fromIntegral <$> FFI.getColumn s)
+    --     <*> (decodeM =<< (liftIO $ FFI.getScope s))
+    --   else fail "omg"
 
 instance DecodeM DecodeAST A.DILocalScope (Ptr FFI.DILocalScope) where
   -- decodeM ls = do


### PR DESCRIPTION
@cocreature, sorry for pinging you here but I figured it would be a little easier to gather feedback on this approach in isolation.

Since the subclass ids aren't exposed through the CI API I figured I'd have to make calls to identify each class individually :(. 

There is one [alternative](https://github.com/xldenis/llvm-hs/pull/2) I can think of: if we can trust that the C++ enum will generate values from `0...` we can hardcode this definition and use that for lookup. I don't know if that's preferred since we'd be relying on a lot of implicitness and this could silently break in new releases (if they reordered Kinds in the enum). 
