### PR TITLE
Implement encoding of DIBasicType and add roundtrip test

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Metadata.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Metadata.hs
@@ -120,7 +120,7 @@ data DIFile = File
   , checksumKind :: ChecksumKind
   } deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
-data ChecksumKind = None | MD5 | SHA1 | Last
+data ChecksumKind = None | MD5 | SHA1
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic, Enum)
 
 data DILocalScope
@@ -158,12 +158,12 @@ data DIType
     , sizeInBits :: Word64
     , alignInBits :: Word32
     , typeEncoding :: Encoding
-    , typeTag :: Word32
+    , typeTag :: Word16
     }
   -- | <https://llvm.org/docs/LangRef.html#dicompositetype>
   -- | <https://llvm.org/doxygen/classllvm_1_1DICompositeType.html>
   | DICompositeType
-    { typeTag :: Word32
+    { typeTag :: Word16
     , typeName :: ShortByteString
     , typeFile :: DIFile
     , typeLine :: Word32
@@ -182,7 +182,7 @@ data DIType
   -- | <https://llvm.org/docs/LangRef.html#diderivedtype>
   -- | <https://llvm.org/doxygen/classllvm_1_1DIDerivedType.html>
   | DIDerivedType
-    { typeTag :: Word32
+    { typeTag :: Word16
     , typeName :: ShortByteString
     , typeFile :: DIFile
     , typeLine :: Word32
@@ -225,6 +225,7 @@ data EnumerationType
   | UnionEnumeration
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
+-- TODO: Consider dropping this type since LLVM allows for other attribute types.
 data Encoding
   = AddressEncoding
   | BooleanEncoding
@@ -234,14 +235,6 @@ data Encoding
   | UnsignedEncoding
   | UnsignedCharEncoding
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
-
-toEncoding 1 = AddressEncoding
-toEncoding 2 = BooleanEncoding
-toEncoding 4 = FloatEncoding
-toEncoding 5 = SignedEncoding
-toEncoding 6 = SignedCharEncoding
-toEncoding 7 = UnsignedEncoding
-toEncoding 8 = UnsignedCharEncoding
 
 data DITemplateParameter
   -- | https://llvm.org/docs/LangRef.html#ditemplatetypeparameter

--- a/llvm-hs/src/LLVM/Exception.hs
+++ b/llvm-hs/src/LLVM/Exception.hs
@@ -17,6 +17,14 @@ data EncodeException =
 
 instance Exception EncodeException
 
+-- | Indicates an error during the translation of LLVM’s internal representation
+-- to the AST provided 'llvm-hs-pure'.
+data DecodeException =
+  DecodeException !String
+  deriving (Show, Eq, Ord, Typeable)
+
+instance Exception DecodeException
+
 -- | Indicates an error during the parsing of a module. This is used
 -- for errors encountered when parsing LLVM’s human readable assembly
 -- format and when parsing the binary bitcode format.

--- a/llvm-hs/src/LLVM/Internal/DecodeAST.hs
+++ b/llvm-hs/src/LLVM/Internal/DecodeAST.hs
@@ -8,6 +8,7 @@ module LLVM.Internal.DecodeAST where
 
 import LLVM.Prelude
 
+import Control.Monad.Catch
 import Control.Monad.State
 import Control.Monad.AnyCont
 
@@ -72,6 +73,7 @@ newtype DecodeAST a = DecodeAST { unDecodeAST :: AnyContT (StateT DecodeState IO
     Monad,
     MonadIO,
     MonadState DecodeState,
+    MonadThrow,
     MonadAnyCont IO,
     ScopeAnyCont
   )

--- a/llvm-hs/src/LLVM/Internal/FFI/Metadata.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Metadata.h
@@ -3,7 +3,7 @@
 
 enum {
 #define HANDLE_METADATA_LEAF(CLASS) CLASS##Kind,
-#include "llvm/ir/Metadata.def"
+#include "llvm/IR/Metadata.def"
 #undef HANDLE_METADATA_LEAF
 } MetadataSubclassId;
 

--- a/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
@@ -221,3 +221,6 @@ foreign import ccall unsafe "LLVM_Hs_DISubroutineTypeArrayLength" getSubroutineT
 
 foreign import ccall unsafe "LLVM_Hs_GetDISubroutineTypeArray" getSubroutineTypeArray ::
   Ptr DIType -> Ptr (Ptr DIType) -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_Get_DIBasicType" getDIBasicType ::
+  Ptr Context -> CUInt -> CString -> Word64 -> Word32 -> CUInt -> IO (Ptr DIType)

--- a/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
@@ -151,13 +151,13 @@ foreign import ccall unsafe "LLVM_Hs_DITypeGetOffsetInBits" getTypeOffsetInBits 
 foreign import ccall unsafe "LLVM_Hs_DIBasicTypeGetEncoding" getBasicTypeEncoding ::
   Ptr DIType -> IO CUInt
 
-foreign import ccall unsafe "LLVM_Hs_DITypeGetTag" getTypeTag ::
-  Ptr DIType -> IO CUInt
+foreign import ccall unsafe "LLVM_Hs_DINodeGetTag" getTag ::
+  Ptr DINode -> IO CUInt
 
 foreign import ccall unsafe "LLVM_Hs_DITypeGetLine" getTypeLine ::
   Ptr DIType -> IO CUInt
 
-foreign import ccall unsafe "LLVM_Hs_DITypeFlags" getTypeFlags ::
+foreign import ccall unsafe "LLVM_Hs_DITypeGetFlags" getTypeFlags ::
   Ptr DIType -> IO CUInt
 
 foreign import ccall unsafe "LLVM_Hs_DICompositeTypeGetElements" getElements ::

--- a/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
@@ -166,6 +166,14 @@ unsigned LLVM_Hs_GetMetadataClassId(LLVMMetadataRef md) {
     return (unwrap(md))->getMetadataID();
 }
 
+unsigned LLVM_Hs_DINodeGetTag(DINode *md) {
+    return md->getTag();
+}
+
+unsigned LLVM_Hs_DITypeGetFlags(DIType *md) {
+    return md->getFlags();
+}
+
 unsigned LLVM_Hs_DILocationGetLine(DILocation *md) {
     return md->getLine();
 }

--- a/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
@@ -254,6 +254,9 @@ unsigned LLVM_Hs_DITypeGetLine(DIType *ds) {
     return ds->getAlignInBits();
 }
 
+DIBasicType* LLVM_Hs_Get_DIBasicType(LLVMContextRef ctx, unsigned tag, const char *name, uint64_t sizeInBits, uint32_t alignInBits, unsigned encoding) {
+    return DIBasicType::get(*unwrap(ctx), tag, name, sizeInBits, alignInBits, encoding);
+}
 unsigned LLVM_Hs_DIBasicTypeGetEncoding(DIBasicType *ds) {
     return ds->getEncoding();
 }

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -159,7 +159,7 @@ instance DecodeM DecodeAST A.DIType (Ptr FFI.DIType) where
         size     <- fmap fromIntegral $ liftIO $ FFI.getTypeSizeInBits diTy
         align    <- fmap fromIntegral $ liftIO $ FFI.getTypeAlignInBits diTy
         encoding <- fmap fromIntegral $ liftIO $ FFI.getBasicTypeEncoding diTy
-        tag      <- fmap fromIntegral $ liftIO $ FFI.getTypeTag diTy
+        tag      <- fmap fromIntegral $ liftIO $ FFI.getTag (FFI.upCast diTy)
 
         return $ A.DIBasicType name size align (A.toEncoding encoding) tag
       [mdSubclassIdP|DICompositeType|]  -> do
@@ -173,7 +173,7 @@ instance DecodeM DecodeAST A.DIType (Ptr FFI.DIType) where
         size     <- fmap fromIntegral $ liftIO $ FFI.getTypeSizeInBits diTy
         align    <- fmap fromIntegral $ liftIO $ FFI.getTypeAlignInBits diTy
         offset   <- fmap fromIntegral $ liftIO $ FFI.getTypeOffsetInBits diTy
-        tag      <- fmap fromIntegral $ liftIO $ FFI.getTypeTag diTy
+        tag      <- fmap fromIntegral $ liftIO $ FFI.getTag (FFI.upCast diTy)
 
         flags <- fmap fromIntegral $ liftIO $ FFI.getTypeFlags diTy
         els   <- decodeM =<< (liftIO $ FFI.getElements diTy)
@@ -212,7 +212,7 @@ instance DecodeM DecodeAST A.DIType (Ptr FFI.DIType) where
         size     <- fmap fromIntegral $ liftIO $ FFI.getTypeSizeInBits diTy
         align    <- fmap fromIntegral $ liftIO $ FFI.getTypeAlignInBits diTy
         offset   <- fmap fromIntegral $ liftIO $ FFI.getTypeOffsetInBits diTy
-        tag      <- fmap fromIntegral $ liftIO $ FFI.getTypeTag diTy
+        tag      <- fmap fromIntegral $ liftIO $ FFI.getTag (FFI.upCast diTy)
 
         flags <- fmap fromIntegral $ liftIO $ FFI.getTypeFlags diTy
 

--- a/llvm-hs/test/LLVM/Test/Metadata.hs
+++ b/llvm-hs/test/LLVM/Test/Metadata.hs
@@ -1,10 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Metadata where
 
+import LLVM.Prelude
+
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+import Test.QuickCheck
 
 import LLVM.Test.Support
+
+import Control.Monad.IO.Class
+import Data.ByteString as B (readFile)
+import qualified Data.ByteString.Short as BSS
+import Foreign.Ptr
 
 import LLVM.AST as A
 import LLVM.AST.Type as A.T
@@ -17,17 +26,47 @@ import LLVM.AST.Global as G
 
 import LLVM.Context
 import LLVM.Module
-
-import Data.ByteString as B (readFile)
+import LLVM.Internal.Coding
+import LLVM.Internal.DecodeAST
+import LLVM.Internal.EncodeAST
+import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
 
 tests = testGroup "Metadata"
   [ globalMetadata
   , namedMetadata
   , nullMetadata
   , cyclicMetadata
+  , roundtripDIType
   , diNode
   ]
 
+arbitrarySbs :: Gen ShortByteString
+arbitrarySbs = BSS.pack <$> listOf (arbitrary `suchThat` (/= 0))
+
+instance Arbitrary Encoding where
+  arbitrary =
+    elements
+      [ AddressEncoding
+      , BooleanEncoding
+      , FloatEncoding
+      , SignedEncoding
+      , SignedCharEncoding
+      , UnsignedEncoding
+      , UnsignedCharEncoding
+      ]
+
+instance Arbitrary DIType where
+  arbitrary =
+    oneof
+      [ DIBasicType <$> arbitrarySbs <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+      -- TODO: Add DICompositeType, DIDerivedType and DISubroutineType
+      ]
+
+roundtripDIType = testProperty "roundtrip DIType" $ \diType -> ioProperty $
+  withContext $ \context -> runEncodeAST context $ do
+    encodedDIType <- encodeM (diType :: DIType)
+    decodedDIType <- liftIO (runDecodeAST (decodeM (encodedDIType :: Ptr FFI.DIType)))
+    pure (decodedDIType === diType)
 
 diNode = testCase "dinodes" $ do
   fStr <- B.readFile "test/module.ll"


### PR DESCRIPTION
This depends on #5 so should be merged after this.

This does not add support for the other constructors of `DIType` but I’d rather take this in small steps so we avoid duplicating work and can make slow but steady progress.